### PR TITLE
Support for conversion from some Python types to MATLAB property maps #28

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -440,6 +440,7 @@ disable=raw-checker-failed,
         use-implicit-booleaness-not-comparison-to-zero,
         use-symbolic-message-instead,
         global-statement,
+        duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/matio/mat_opaque_tools.py
+++ b/matio/mat_opaque_tools.py
@@ -22,6 +22,8 @@ from matio.utils import (
     mat_to_table,
     mat_to_timetable,
     string_to_mat,
+    table_to_mat,
+    timetable_to_mat,
 )
 
 MAT_TO_PY = {
@@ -44,8 +46,8 @@ PY_TO_MAT = {
     "dictionary": dictionary_to_mat,
     "duration": duration_to_mat,
     "string": string_to_mat,
-    # "table": table_to_mat,
-    # "timetable": timetable_to_mat,
+    "table": table_to_mat,
+    "timetable": timetable_to_mat,
 }
 
 
@@ -82,7 +84,7 @@ def convert_mat_to_py(obj, **kwargs):
     return obj
 
 
-def convert_py_to_mat(properties, classname, oned_as):
+def convert_py_to_mat(properties, classname, oned_as, use_strings):
     """Convert a Python object to a MATLAB object"""
 
     convert_func = PY_TO_MAT.get(classname)
@@ -93,7 +95,7 @@ def convert_py_to_mat(properties, classname, oned_as):
         )
         return {}
 
-    return convert_func(properties, oned_as=oned_as)
+    return convert_func(properties, oned_as=oned_as, use_strings=use_strings)
 
 
 def mat_to_enum(values, value_names, class_name, shapes):

--- a/matio/mat_opaque_tools.py
+++ b/matio/mat_opaque_tools.py
@@ -1,11 +1,17 @@
 """Convert MATLAB objects to Python compatible objects"""
 
+import warnings
 from enum import Enum
 
 import numpy as np
 from pandas import Categorical, DataFrame
 
 from matio.utils import (
+    calendarduration_to_mat,
+    containermap_to_mat,
+    datetime_to_mat,
+    dictionary_to_mat,
+    duration_to_mat,
     mat_to_calendarduration,
     mat_to_categorical,
     mat_to_containermap,
@@ -15,9 +21,10 @@ from matio.utils import (
     mat_to_string,
     mat_to_table,
     mat_to_timetable,
+    string_to_mat,
 )
 
-CLASS_TO_FUNCTION = {
+MAT_TO_PY = {
     "calendarDuration": mat_to_calendarduration,
     "categorical": mat_to_categorical,
     "containers.Map": mat_to_containermap,
@@ -27,6 +34,18 @@ CLASS_TO_FUNCTION = {
     "string": mat_to_string,
     "table": mat_to_table,
     "timetable": mat_to_timetable,
+}
+
+PY_TO_MAT = {
+    "calendarDuration": calendarduration_to_mat,
+    # "categorical": categorical_to_mat,
+    "containers.Map": containermap_to_mat,
+    "datetime": datetime_to_mat,
+    "dictionary": dictionary_to_mat,
+    "duration": duration_to_mat,
+    "string": string_to_mat,
+    # "table": table_to_mat,
+    # "timetable": timetable_to_mat,
 }
 
 
@@ -53,7 +72,7 @@ class MatioOpaque:
 
 def convert_mat_to_py(obj, **kwargs):
     """Converts a MATLAB object to a Python object"""
-    convert_func = CLASS_TO_FUNCTION.get(obj.classname)
+    convert_func = MAT_TO_PY.get(obj.classname)
     if convert_func is not None:
         return convert_func(
             obj.properties,
@@ -61,6 +80,20 @@ def convert_mat_to_py(obj, **kwargs):
             add_table_attrs=kwargs.get("add_table_attrs", None),
         )
     return obj
+
+
+def convert_py_to_mat(properties, classname, oned_as):
+    """Convert a Python object to a MATLAB object"""
+
+    convert_func = PY_TO_MAT.get(classname)
+    if convert_func is None:
+        warnings.warn(
+            f"Conversion of {type(properties)} into MATLAB type "
+            f"{classname} is not yet implemented. This will be skipped"
+        )
+        return {}
+
+    return convert_func(properties, oned_as=oned_as)
 
 
 def mat_to_enum(values, value_names, class_name, shapes):
@@ -94,9 +127,8 @@ def guess_class_name(properties):
         classname = "categorical"
     elif isinstance(properties, dict):
         classname = "containers.Map"
-    elif isinstance(properties, list):
-        if all(isinstance(item, tuple) and len(item) == 2 for item in properties):
-            classname = "dictionary"
+    elif isinstance(properties, tuple):
+        classname = "dictionary"
     elif isinstance(properties, np.ndarray):
         if properties.dtype.names is not None:
             classname = "calendarDuration"
@@ -109,8 +141,8 @@ def guess_class_name(properties):
 
     if classname is None:
         raise ValueError(
-            f"Unable to determine MATLAB class equivalent for properties of \
-                type {type(properties).__name__}. Provide it explicitly."
+            f"Unable to determine MATLAB class equivalent for properties of "
+            f"type {type(properties)}. Provide it explicitly."
         )
 
     return classname

--- a/matio/matio5.py
+++ b/matio/matio5.py
@@ -151,13 +151,18 @@ def read_matfile5(
 
 
 def save_matfile5(
-    file_stream, mdict, do_compression=False, global_vars=None, oned_as="row"
+    file_stream,
+    mdict,
+    do_compression=False,
+    global_vars=None,
+    oned_as="row",
+    use_strings=True,
 ):
     """Saves variables to MAT-file 5 format (< 7.3)"""
 
     with get_matio_context():
         file_wrapper = set_file_wrapper()
-        file_wrapper.init_save(oned_as)
+        file_wrapper.init_save(oned_as, use_strings)
 
         mdict = parse_input_dict(mdict)
     subsys_data = mdict.pop("__subsystem__", None)

--- a/matio/matio5.py
+++ b/matio/matio5.py
@@ -141,8 +141,8 @@ def read_matfile5(
 
     with get_matio_context():
 
-        file_wrapper = set_file_wrapper(byte_order, raw_data, add_table_attrs)
-        file_wrapper.init_load(fwrap_data)
+        file_wrapper = set_file_wrapper()
+        file_wrapper.init_load(fwrap_data, byte_order, raw_data, add_table_attrs)
 
         for var, data in matfile_dict.items():
             matfile_dict[var] = find_matlab_opaque(data)
@@ -157,7 +157,7 @@ def save_matfile5(
 
     with get_matio_context():
         file_wrapper = set_file_wrapper()
-        file_wrapper.init_save()
+        file_wrapper.init_save(oned_as)
 
         mdict = parse_input_dict(mdict)
     subsys_data = mdict.pop("__subsystem__", None)

--- a/matio/matio7.py
+++ b/matio/matio7.py
@@ -38,8 +38,8 @@ class MatRead7:
         subsystem_arr = self.read_struct(self.h5stream["#subsystem#"])
         if "MCOS" in subsystem_arr.dtype.names:
             fwrap_data = subsystem_arr[0, 0]["MCOS"]
-            file_wrapper = set_file_wrapper(byte_order, raw_data, add_table_attrs)
-            file_wrapper.init_load(fwrap_data)
+            file_wrapper = set_file_wrapper()
+            file_wrapper.init_load(fwrap_data, byte_order, raw_data, add_table_attrs)
 
     def read_int(self, obj, is_empty=0):
         """Reads MATLAB integer arrays from the v7.3 MAT-file."""

--- a/matio/matio_base.py
+++ b/matio/matio_base.py
@@ -74,6 +74,7 @@ def save_to_mat(
     do_compression=False,
     global_vars=None,
     oned_as="row",
+    use_strings=True,
 ):
     """Saves variables to MAT-file
     Inputs
@@ -96,7 +97,7 @@ def save_to_mat(
 
     if version == "v7":
         subsys_offset = save_matfile5(
-            file_stream, mdict_copy, do_compression, global_vars, oned_as
+            file_stream, mdict_copy, do_compression, global_vars, oned_as, use_strings
         )
     elif version == "v7.3":
         raise NotImplementedError("v7.3 MAT-file saving is not implemented")

--- a/matio/subsystem.py
+++ b/matio/subsystem.py
@@ -250,7 +250,7 @@ class FileWrapper:
         """Initializes save with metadata for object ID = 0"""
 
         self.oned_as = oned_as
-        self.use_strings = True
+        self.use_strings = use_strings
         self.class_id_metadata.extend([0, 0, 0, 0])
         self.object_id_metadata.extend([0, 0, 0, 0, 0, 0])
         self.saveobj_prop_metadata.extend([0, 0])

--- a/matio/utils/__init__.py
+++ b/matio/utils/__init__.py
@@ -7,7 +7,13 @@ from .matmap import (
     mat_to_dictionary,
 )
 from .matstring import mat_to_string, string_to_mat
-from .mattables import mat_to_categorical, mat_to_table, mat_to_timetable
+from .mattables import (
+    mat_to_categorical,
+    mat_to_table,
+    mat_to_timetable,
+    table_to_mat,
+    timetable_to_mat,
+)
 from .mattimes import (
     calendarduration_to_mat,
     datetime_to_mat,
@@ -33,4 +39,6 @@ __all__ = [
     "calendarduration_to_mat",
     "dictionary_to_mat",
     "containermap_to_mat",
+    "table_to_mat",
+    "timetable_to_mat",
 ]

--- a/matio/utils/__init__.py
+++ b/matio/utils/__init__.py
@@ -1,9 +1,21 @@
 """Conversion utilities for matio"""
 
-from .matmap import mat_to_containermap, mat_to_dictionary
-from .matstring import mat_to_string
+from .matmap import (
+    containermap_to_mat,
+    dictionary_to_mat,
+    mat_to_containermap,
+    mat_to_dictionary,
+)
+from .matstring import mat_to_string, string_to_mat
 from .mattables import mat_to_categorical, mat_to_table, mat_to_timetable
-from .mattimes import mat_to_calendarduration, mat_to_datetime, mat_to_duration
+from .mattimes import (
+    calendarduration_to_mat,
+    datetime_to_mat,
+    duration_to_mat,
+    mat_to_calendarduration,
+    mat_to_datetime,
+    mat_to_duration,
+)
 
 __all__ = [
     "mat_to_containermap",
@@ -15,4 +27,10 @@ __all__ = [
     "mat_to_calendarduration",
     "mat_to_datetime",
     "mat_to_duration",
+    "string_to_mat",
+    "datetime_to_mat",
+    "duration_to_mat",
+    "calendarduration_to_mat",
+    "dictionary_to_mat",
+    "containermap_to_mat",
 ]

--- a/matio/utils/matmap.py
+++ b/matio/utils/matmap.py
@@ -2,6 +2,8 @@
 
 import warnings
 
+import numpy as np
+
 MAT_DICT_VERSION = 1
 
 
@@ -39,7 +41,109 @@ def mat_to_dictionary(props, **_kwargs):
         )
         return props
 
-    ks = comps[0, 0]["Key"].ravel()
-    vals = comps[0, 0]["Value"].ravel()
+    ks = comps[0, 0]["Key"]
+    vals = comps[0, 0]["Value"]
 
-    return list(zip(ks, vals))
+    return (ks, vals)
+
+
+def dictionary_to_mat(props, **_kwargs):
+    """Converts a Python dictionary to MATLAB dictionary"""
+    if not (isinstance(props, tuple) and len(props) == 2):
+        raise TypeError("Expected tuple of (key, value)")
+
+    keys, values = props
+
+    def is_valid_array(obj):
+        return (
+            isinstance(obj, np.ndarray) or getattr(obj, "classname", None) == "string"
+        )
+
+    if not is_valid_array(keys) or not is_valid_array(values):
+        raise TypeError(
+            "Keys must be a numpy array or MatioOpaque with classname='string'"
+        )
+
+    dtype = [
+        ("Version", object),
+        ("IsKeyCombined", object),
+        ("IsValueCombined", object),
+        ("Key", object),
+        ("Value", object),
+    ]
+    data_arr = np.empty((1, 1), dtype=dtype)
+
+    data_arr["Key"][0, 0] = keys
+    data_arr["Value"][0, 0] = values
+    data_arr["Version"][0, 0] = np.uint64(MAT_DICT_VERSION)
+    data_arr["IsKeyCombined"][0, 0] = np.array(True, dtype=np.bool_)
+    data_arr["IsValueCombined"][0, 0] = np.array(True, dtype=np.bool_)
+
+    prop_map = {
+        "data": data_arr,
+    }
+
+    return prop_map
+
+
+def containermap_to_mat(props, **_kwargs):
+    """Converts a Python dictionary to MATLAB container.Map"""
+    if not isinstance(props, dict):
+        raise TypeError(f"Expected dict, got {type(props)}")
+    if "serialization" in props:
+        warnings.warn(
+            "Key 'Serialization' was found in the map. This clashes with an expected MATLAB "
+            "keyword and will be treated as a raw property map."
+        )
+        return props
+
+    keys = list(props.keys())
+    vals = list(props.values())
+
+    val_arr = np.empty((1, len(vals)), dtype=object)
+    keys_arr = np.empty((1, len(keys)), dtype=object)
+    val_arr[0, :] = vals
+    keys_arr[0, :] = keys
+
+    if all(isinstance(k, str) for k in keys):
+        key_type = "char"
+    elif all(isinstance(k, int) for k in keys):
+        key_type = "uint64"
+        # Defaulting to highest precision as Python doesn't differentiate
+    else:
+        key_type = "double"
+
+    value_dtypes = {v.dtype for v in vals if isinstance(v, np.ndarray)}
+    if len(value_dtypes) == 1:
+        uniformity = True
+        dtype_map = {
+            np.dtype("float64"): "double",
+            np.dtype("float32"): "single",
+            np.dtype("bool"): "logical",
+            np.dtype("int8"): "int8",
+            np.dtype("uint8"): "uint8",
+            np.dtype("int16"): "int16",
+            np.dtype("uint16"): "uint16",
+            np.dtype("int32"): "int32",
+            np.dtype("uint32"): "uint32",
+            np.dtype("int64"): "int64",
+            np.dtype("uint64"): "uint64",
+        }
+        value_type = dtype_map.get(next(iter(value_dtypes)), "any")
+    else:
+        uniformity = False
+        value_type = "any"
+
+    ser_dtype = [
+        ("keys", object),
+        ("values", object),
+        ("uniformity", object),
+        ("keyType", object),
+        ("valueType", object),
+    ]
+    serialization = np.empty((1, 1), dtype=ser_dtype)
+    serialization[0, 0] = (keys_arr, val_arr, uniformity, key_type, value_type)
+    prop_map = {
+        "serialization": serialization,
+    }
+    return prop_map

--- a/matio/utils/mattables.py
+++ b/matio/utils/mattables.py
@@ -208,6 +208,7 @@ def mat_to_categorical(props, **_kwargs):
 
 
 def make_table_props():
+    """Creates default properties for a MATLAB table"""
     dtype = [
         ("useVariableNamesOriginal", object),
         ("useDimensionNamesOriginal", object),
@@ -251,7 +252,7 @@ def make_table_props():
     return props
 
 
-def table_to_mat(df, use_strings=True, **_kwargs):
+def table_to_mat(df, **_kwargs):
     """Converts a pandas DataFrame to a MATLAB table"""
 
     if not isinstance(df, pd.DataFrame):
@@ -286,6 +287,7 @@ def table_to_mat(df, use_strings=True, **_kwargs):
 
 
 def make_timetable_props():
+    """Creates default properties for a MATLAB timetable"""
 
     arrayprops_dtype = [
         ("Description", object),
@@ -316,7 +318,7 @@ def make_timetable_props():
     }
 
 
-def timetable_to_mat(df, rowtimes=None, use_strings=True, **_kwargs):
+def timetable_to_mat(df, **_kwargs):
     """Converts a pandas DataFrame to a MATLAB timetable"""
 
     if not isinstance(df, pd.DataFrame):
@@ -334,15 +336,10 @@ def timetable_to_mat(df, rowtimes=None, use_strings=True, **_kwargs):
         [np.array(["Time"]), np.array(["Variables"])], dtype=object
     ).reshape((1, 2))
 
-    if rowtimes is None:
-        if isinstance(df.index, pd.DatetimeIndex):
-            rowtimes = df.index.to_numpy()
-        else:
-            raise ValueError(
-                "Timetable requires datetime row index or explicit rowtimes"
-            )
+    if isinstance(df.index, pd.DatetimeIndex):
+        rowtimes = df.index.to_numpy()
     else:
-        rowtimes = np.asarray(rowtimes)
+        raise ValueError("Timetable requires datetime row index or explicit rowtimes")
 
     # Define timetable struct dtype
     timetable_dtype = [
@@ -355,7 +352,7 @@ def timetable_to_mat(df, rowtimes=None, use_strings=True, **_kwargs):
     ]
 
     extras = make_timetable_props()
-    timetable_dtype.extend((key, object) for key in extras.keys())
+    timetable_dtype.extend((key, object) for key in extras)
 
     # Create 1x1 structured array
     timetable = np.empty((1, 1), dtype=timetable_dtype)
@@ -366,7 +363,7 @@ def timetable_to_mat(df, rowtimes=None, use_strings=True, **_kwargs):
     timetable[0, 0]["numVars"] = nvars
     timetable[0, 0]["rowTimes"] = rowtimes.reshape((-1, 1))
 
-    for key in extras:
-        timetable[0, 0][key] = extras[key]
+    for key, value in extras.items():
+        timetable[0, 0][key] = value
 
     return {"any": timetable}

--- a/matio/utils/mattimes.py
+++ b/matio/utils/mattimes.py
@@ -89,7 +89,7 @@ def mat_to_calendarduration(props, **_kwargs):
     return comps
 
 
-def datetime_to_mat(arr, oned_as="row"):
+def datetime_to_mat(arr, oned_as="row", **_kwargs):
     """Convert numpy.datetime64 array to MATLAB datetime format."""
     if not isinstance(arr, np.ndarray):
         raise TypeError(f"Expected numpy.ndarray, got {type(arr)}")
@@ -120,7 +120,7 @@ def datetime_to_mat(arr, oned_as="row"):
     return prop_map
 
 
-def duration_to_mat(arr, oned_as="row"):
+def duration_to_mat(arr, oned_as="row", **_kwargs):
     """Convert numpy timedelta64 array to MATLAB duration format."""
     if not isinstance(arr, np.ndarray):
         raise TypeError(f"Expected numpy.ndarray, got {type(arr)}")

--- a/tests/test_mcos/test_calendarDuration/test_calendarDuration.py
+++ b/tests/test_mcos/test_calendarDuration/test_calendarDuration.py
@@ -16,17 +16,17 @@ params = [
     ),
     (
         (
-            np.array([[0, 0, 0]], dtype="timedelta64[M]"),
+            np.array([[0]], dtype="timedelta64[M]"),
             np.array([[1, 2, 3]], dtype="timedelta64[D]"),
-            np.array([[0, 0, 0]], dtype="timedelta64[ms]"),
+            np.array([[0]], dtype="timedelta64[ms]"),
         ),
         "cdur2",
     ),
     (
         (
-            np.array([[0, 0]], dtype="timedelta64[M]"),
+            np.array([[0]], dtype="timedelta64[M]"),
             np.array([[7, 14]], dtype="timedelta64[D]"),
-            np.array([[0, 0]], dtype="timedelta64[ms]"),
+            np.array([[0]], dtype="timedelta64[ms]"),
         ),
         "cdur3",
     ),
@@ -34,15 +34,15 @@ params = [
         (
             np.array([[1, 0]], dtype="timedelta64[M]"),
             np.array([[1, 2]], dtype="timedelta64[D]"),
-            np.array([[0, 0]], dtype="timedelta64[ms]"),
+            np.array([[0]], dtype="timedelta64[ms]"),
         ),
         "cdur4",
     ),
     (
         (
             np.array([[12, 18]], dtype="timedelta64[M]"),
-            np.array([[0, 0]], dtype="timedelta64[D]"),
-            np.array([[0, 0]], dtype="timedelta64[ms]"),
+            np.array([[0]], dtype="timedelta64[D]"),
+            np.array([[0]], dtype="timedelta64[ms]"),
         ),
         "cdur5",
     ),
@@ -87,14 +87,14 @@ params = [
         "calendarDuration-duration-v7",
     ],
 )
-def test_duration_load_v7(expected_array, var_name):
+def test_calendarduration_load_v7(expected_array, var_name):
     file_path_v7 = os.path.join(os.path.dirname(__file__), "test_caldur_v7.mat")
     matdict = load_from_mat(file_path_v7, raw_data=False)
 
     assert var_name in matdict
-    assert np.array_equal(matdict[var_name]["months"], expected_array[0])
-    assert np.array_equal(matdict[var_name]["days"], expected_array[1])
-    assert np.array_equal(matdict[var_name]["millis"], expected_array[2])
+    assert np.array_equal(matdict[var_name][0, 0]["months"], expected_array[0])
+    assert np.array_equal(matdict[var_name][0, 0]["days"], expected_array[1])
+    assert np.array_equal(matdict[var_name][0, 0]["millis"], expected_array[2])
 
 
 @pytest.mark.parametrize(
@@ -111,11 +111,11 @@ def test_duration_load_v7(expected_array, var_name):
         "calendarDuration-duration-v7.3",
     ],
 )
-def test_duration_load_v73(expected_array, var_name):
+def test_calendarduration_load_v73(expected_array, var_name):
     file_path_v73 = os.path.join(os.path.dirname(__file__), "test_caldur_v73.mat")
     matdict = load_from_mat(file_path_v73, raw_data=False)
 
     assert var_name in matdict
-    assert np.array_equal(matdict[var_name]["months"], expected_array[0])
-    assert np.array_equal(matdict[var_name]["days"], expected_array[1])
-    assert np.array_equal(matdict[var_name]["millis"], expected_array[2])
+    assert np.array_equal(matdict[var_name][0, 0]["months"], expected_array[0])
+    assert np.array_equal(matdict[var_name][0, 0]["days"], expected_array[1])
+    assert np.array_equal(matdict[var_name][0, 0]["millis"], expected_array[2])

--- a/tests/test_mcos/test_dict/test_dict.py
+++ b/tests/test_mcos/test_dict/test_dict.py
@@ -7,34 +7,33 @@ from matio import load_from_mat
 
 params = [
     (
-        [
-            (np.float64(1), np.str_("apple")),
-            (np.float64(2), np.str_("banana")),
-            (np.float64(3), np.str_("cherry")),
-        ],
+        (
+            np.array([[1.0, 2.0, 3.0]]).reshape(-1, 1),
+            np.array(["apple", "banana", "cherry"]).reshape(-1, 1),
+        ),
         "dict1",
     ),
     (
-        [
-            (np.str_("x"), np.float64(10)),
-            (np.str_("y"), np.float64(20)),
-            (np.str_("z"), np.float64(30)),
-        ],
+        (
+            np.array(["x", "y", "z"]).reshape(-1, 1),
+            np.array([10.0, 20.0, 30.0]).reshape(-1, 1),
+        ),
         "dict2",
     ),
     (
-        [
-            (np.str_("name"), np.array([["Alice"]])),
-            (np.str_("age"), np.array([[25]])),
-        ],
+        (
+            np.array([["name", "age"]]).reshape(-1, 1),
+            np.array([np.array(["Alice"]), np.array([25.0])], dtype=object).reshape(
+                -1, 1
+            ),
+        ),
         "dict3",
     ),
     (
-        [
-            (np.array([[1]]), np.str_("one")),
-            (np.array([[2]]), np.str_("two")),
-            (np.array([[3]]), np.str_("three")),
-        ],
+        (
+            np.array([[1, 2, 3]]).reshape(-1, 1),
+            np.array(["one", "two", "three"]).reshape(-1, 1),
+        ),
         "dict4",
     ),
 ]
@@ -55,11 +54,8 @@ def test_dict_load_v7(expected_array, var_name):
     matdict = load_from_mat(file_path_v7, raw_data=False)
 
     assert var_name in matdict
-    for i, (expected_key, expected_val) in enumerate(expected_array):
-        actual_key = matdict[var_name][i][0]
-        actual_val = matdict[var_name][i][1]
-        assert np.array_equal(actual_key, expected_key)
-        assert np.array_equal(actual_val, expected_val)
+    assert np.array_equal(matdict[var_name][0], expected_array[0])
+    assert np.array_equal(matdict[var_name][1], expected_array[1])
 
 
 @pytest.mark.parametrize(
@@ -77,8 +73,5 @@ def test_containermap_load_v73(expected_array, var_name):
     matdict = load_from_mat(file_path_v73, raw_data=False)
 
     assert var_name in matdict
-    for i, (expected_key, expected_val) in enumerate(expected_array):
-        actual_key = matdict[var_name][i][0]
-        actual_val = matdict[var_name][i][1]
-        assert np.array_equal(actual_key, expected_key)
-        assert np.array_equal(actual_val, expected_val)
+    assert np.array_equal(matdict[var_name][0], expected_array[0])
+    assert np.array_equal(matdict[var_name][1], expected_array[1])


### PR DESCRIPTION
## Update return type for MATLAB dictionary and calendarDuration
* dictionary returned as single tuple of (key, value)
* Undo array broadcasting for calendarDuration. Return value is now raw data but type casted
* Updated tests to reflect new return types

## Update load-save initialization to support different load-save arguments

* Moved load arguments to FileWrapper.init_load()
* Moved save arguments to FileWrapper.init_save()
* set_filewrapper() does not accept any arguments
* New FileWrapper attribute "oned_as" to reshape numpy vectors
* matio/matio5.py: Update function calls
* matio/matio7.py: Update function calls
* matio/subsystem.py: Update function definitions

## Support for conversion from some Python types to MATLAB property maps

* matio/utils/matmap.py: New methods to convert container.Map and dictionary
* matio/utils/mattimes.py: New methods to convert datetime, duration and calendarDuration
* matio/utils/matstring.py: New method to convert string
* matio/utils/__init__.py: Updated to expose new methods
* matio/mat_opaque_tools.py: New methods to convert from python to MAT

TODO:
Add conversion utils for table, timetable and categorical