### PR TITLE
Fix: get_dynamic_properties() returns an empty dict if dyn_prop_metadata is empty

### DIFF
--- a/matio/subsystem/subsys.py
+++ b/matio/subsystem/subsys.py
@@ -381,6 +381,10 @@ class MatSubsystem:
     def get_dynamic_properties(self, dep_id):
         """Returns dynamicproperties (as dict) for a given object based on dependency ID"""
 
+        if self.dynprop_metadata.size == 0:
+            # Newer versions don't write dynamic property metadata if there's none
+            return {}
+
         offset = self.dynprop_metadata[0]
         for i in range(dep_id):
             nprops = self.dynprop_metadata[offset]


### PR DESCRIPTION
Newer MATLAB versions seem to omit dynprop_metadata altogether if there are no dynamic properties to save. This fix should cover the case when this metadata field is empty.

Fixes https://github.com/JuliaIO/MAT.jl/issues/212