### PR TITLE
Fix: Use signed ints for traversing filewrapper metadata

### DIFF
--- a/matio/subsystem/subsys.py
+++ b/matio/subsystem/subsys.py
@@ -49,7 +49,7 @@ class MatSubsystem:
         oned_as="col",
         saveobj_classes=[],
     ):
-        self.byte_order = "<u4" if byte_order[0] == "<" else ">u4"
+        self.byte_order = "<i4" if byte_order[0] == "<" else ">i4"
         self.raw_data = raw_data
         self.add_table_attrs = add_table_attrs
         self.oned_as = oned_as
@@ -432,7 +432,7 @@ class MatSubsystem:
     def get_dynamic_properties(self, dep_id):
         """Returns dynamicproperties (as dict) for a given object based on dependency ID"""
 
-        if dep_id == 0:
+        if self.dynprop_metadata.size == 0:
             # Newer versions don't write dynamic property metadata for some builtin types like string
             return {}
 
@@ -468,10 +468,8 @@ class MatSubsystem:
         """Returns the properties as a dict for a given object ID"""
 
         if object_id == 0:
-            # Matlab uses an object ID=0
-            # MATLAB seems to keep references to deleted objects
-            # Observed this in fig files I think? Don't remember
-            # objectID=0 may be a placeholder for such cases
+            # MATLAB keeps (weak?) references to objects for some reason
+            # Deleted objects are represented with objID = 0
             return None
 
         class_id, saveobj_id, normobj_id, dep_id = self.get_object_metadata(object_id)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,6 +7,10 @@ import pytest
 from matio import load_from_mat, save_to_mat
 from matio.utils.matclass import MatWriteWarning
 
+# Check for availability of extended precision types in numpy
+HAS_FLOAT128 = hasattr(np, "float128")
+HAS_COMPLEX256 = hasattr(np, "complex256")
+
 files = [("test_basic_v7.mat", "v7"), ("test_basic_v73.mat", "v7.3")]
 
 
@@ -626,6 +630,9 @@ class TestSaveBasicDatatypes:
 @pytest.mark.parametrize("filename, version", files)
 class TestWriteNonSupportedNumeric:
 
+    @pytest.mark.skipif(
+        not HAS_FLOAT128, reason="np.float128 not available on this platform"
+    )
     def test_numpy_floats(self, filename, version):
         """Test writing numpy float16 data to MAT-file"""
         arr_16 = np.array([1, 2, 3], dtype=np.float16).reshape(1, 3)
@@ -656,6 +663,9 @@ class TestWriteNonSupportedNumeric:
             if os.path.exists(temp_file_path):
                 os.remove(temp_file_path)
 
+    @pytest.mark.skipif(
+        not HAS_COMPLEX256, reason="np.complex256 not available on this platform"
+    )
     def test_numpy_complex(self, filename, version):
         """Test writing numpy complex64 and complex256 data to MAT-file"""
         arr_c64 = np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex64).reshape(1, 3)


### PR DESCRIPTION
* subsys.py: Use signed int32 during load
* subsys.py: Improve comments
* test_basic.py: Skip unsupported NumPy dtypes if not available on OS

Fixes #50 