### PR TITLE
Update README and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,11 @@ The `mat-io` module provides tools for loading and saving MAT-files, including M
 - `string`
 - `datetime`, `duration` and `calendarDuration`
 - `table` and `timetable`
-- `containers.Map` and `dictionary`
+- `containers.Map`
 - `categorical`
 - Enumeration Instance Arrays
 
-MAT-file versions `v6`, `v7` and `v7.3` are supported.
-
-- Versions `v6` and `v7` uses a modified version of `scipy.io` under the hood
-- Version `v7.3` uses `h5py` to write in the HDF5 format.
-
-Data is returned in the same format as `scipy.io.loadmat` does.
+Data is returned in the same format as `scipy.io.loadmat`, i.e., as a dictionary of `{var_name: var_data}`.
 
 ## Installation
 
@@ -43,6 +38,8 @@ data = load_from_mat(
 - `add_table_attrs`: If `True`, adds custom Matlab Table or Timetable properties as `pandas.DataFrame` attributes.
 - `mdict`: If provided, this dictionary will be updated with the data from a MAT-file.
 - `variable_names`: A list of variable names to load from file.
+
+Supported MAT-file versions are `v4`, `v6`, `v7` and `v7.3`.
 
 ### Saving MAT-files
 

--- a/docs/field_contents.md
+++ b/docs/field_contents.md
@@ -32,7 +32,6 @@ The `matio` package attempts to convert some common MATLAB datatypes into a Pyth
 | `table`                           | `pandas.DataFrame`                          |
 | `timetable`                       | `pandas.DataFrame` with datetime or duration index      |
 | `containers.Map`                  | `MatlabContainerMap` instance subclassed from `collections.UserDict` |
-| `dictionary`                      | TODO                                     |
 | `categorical`                     | `pandas.Categorical`                        |
 | Enumeration Instance Arrays       | `MatlabEnumerationArray` instance where each element is `enum.Enum`    |
 | Object Scalar                     | `MatlabOpaque` instance with property map `dict` |
@@ -166,7 +165,7 @@ Objects of this class contain a single property `data` which is defined as a `st
 4. `Key`
 5. `Value`
 
-Since keys can be of any MATLAB datatype, including object instances, `matio.load_from_mat` converts this into a tuple `(keys, values)`. Each value in the tuple contains all the keys and values for the dictionary. These values are not split up as MATLAB optimizes on object representation.
+Since keys of MATLAB dictionaries can be of any MATLAB datatype, `matio.load_from_mat` does not currently use a Pythonic representation and instead returns raw data for variables of this type.
 
 ## `categorical`
 


### PR DESCRIPTION
Removes MATLAB `dictionary` as a natively supported type. MATLAB dictionaries are difficult to map cleanly to Python dictionaries because keys can be arbitrary MATLAB datatypes. Proper support would likely require a dedicated `AbstractDict` implementation and additional APIs, which is outside the scope of this module.